### PR TITLE
詰めて表示するモード追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,7 +1,8 @@
-chrome.storage.sync.get(['chordstyleOption', 'wordstyleOption', 'greenbackOption'], function(item) {
+chrome.storage.sync.get(['chordstyleOption', 'wordstyleOption', 'greenbackOption', 'compactOption'], function(item) {
   const chordstyleOption = item.chordstyleOption || 'bold';
   const wordstyleOption = item.wordstyleOption || 'normal';
   const greenbackOption = item.greenbackOption || 'disable';
+  const compactOption = item.compactOption || false;
   let chordfontSize, chordfontWeight, chordtop, lineHeight;
   let wordfontWeight;
   let background;
@@ -86,4 +87,50 @@ chrome.storage.sync.get(['chordstyleOption', 'wordstyleOption', 'greenbackOption
   });
 
   document.body.style.backgroundColor = background;
+
+  if (compactOption) {
+    // Wrap every `span.chord` and `span.word` pair with `span.chordword`
+    document.querySelectorAll(".main .line").forEach(function(line) {
+      const p = document.createElement("p");
+      while (line.children.length > 0) {
+        const chord = line.children[0];
+        const word = line.children[1];
+        if (chord.classList.contains("chord") && 
+            word && word.classList.contains("word")) {
+          const span = document.createElement("span");
+          span.classList = "chordword";
+          span.appendChild(chord);
+          span.appendChild(word);
+          p.appendChild(span);
+        } else {
+          p.appendChild(chord);
+        }
+      }
+      line.innerHTML = p.innerHTML;
+    });
+    const styleSheet = new CSSStyleSheet();
+    styleSheet.replaceSync(`
+      div.main span.chordword {
+        display: inline-flex;
+        flex-direction: column;
+      }
+      div.main span.chord, div.main span.word, div.main span.wordtop {
+        position: static;
+        line-height: 1em;
+      }
+      div.main span.wordtop {
+        vertical-align: bottom;
+      }
+      div.main span.chord {
+        margin-right: 6px;
+      }
+      div.main span.word {
+        white-space: pre;
+      }
+      div.main p.line {
+        margin-block: 0 .3em;
+      }
+    `);
+    document.adoptedStyleSheets = [styleSheet];
+  }
 });

--- a/options.html
+++ b/options.html
@@ -28,6 +28,10 @@
             <option value="enable">Enable</option>
         </select>
     </div>
+    <div>
+        <label for="compactOption">Compact mode:</label>
+        <input type="checkbox" id="compactOption" />
+    </div>
     <button id="save">Save</button>
     <script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -3,16 +3,18 @@ document.getElementById('save').addEventListener('click', function() {
     const chordstyleOption = document.getElementById('chordstyleOption').value;
     const wordstyleOption = document.getElementById('wordstyleOption').value;
     const greenbackOption = document.getElementById('greenbackOption').value;
-    chrome.storage.sync.set({chordstyleOption, wordstyleOption, greenbackOption}, function() {
+    const compactOption = document.getElementById('compactOption').checked;
+    chrome.storage.sync.set({chordstyleOption, wordstyleOption, greenbackOption, compactOption}, function() {
         console.log('Option saved.');
     });
 });
 
 // Load the saved options
 document.addEventListener('DOMContentLoaded', function() {
-    chrome.storage.sync.get(['chordstyleOption', 'wordstyleOption', 'greenbackOption'], function(item) {
+    chrome.storage.sync.get(['chordstyleOption', 'wordstyleOption', 'greenbackOption', 'compactOption'], function(item) {
         document.getElementById('chordstyleOption').value = item.styleOption || 'bold';
         document.getElementById('wordstyleOption').value = item.styleOption || 'normal';
         document.getElementById('greenbackOption').value = item.styleOption || 'disable';
+        document.getElementById('compactOption').checked = item.compactOption || false;
     });
 });


### PR DESCRIPTION
### 概要
コードをでっかくしたときに歌詞同士がめっちゃ開いちゃうのをぎゅっとするモードを追加したよ

### コンパクト表示オフ → オン

Bold-VeryLarge のときの表示

![image](https://github.com/user-attachments/assets/44c53e9c-7638-4c48-8c5f-af4eda733916)

### 設定画面
![image](https://github.com/user-attachments/assets/b4252e49-e202-4d67-a13e-53be214b4e86)
