### PR TITLE
コードの略記を充実

### DIFF
--- a/content.js
+++ b/content.js
@@ -144,10 +144,11 @@ function applyStyleFromStorage() {
         if (!chord.getAttribute("chord")) {
           chord.setAttribute("chord", chord.innerText);
         }
-        chord.innerText = chord
+        chord.innerHTML = chord
           .getAttribute("chord")
           .replaceAll("b", "\u266D")
           .replaceAll("#", "\u266F")
+          .replaceAll(/(.+)(\(.+?\))/g, "$1<sup>$2</sup>")
           .replaceAll(/Maj|maj|M/g, "\uE18A");
       });
       const styleSheet = new CSSStyleSheet();

--- a/content.js
+++ b/content.js
@@ -49,6 +49,10 @@ const options = [
   "compactOption",
   "greenbackOption",
   "columnCount",
+  "replaceMaj",
+  "replaceAug",
+  "replaceDim",
+  "replaceHalfDim",
 ];
 
 function applyStyleFromStorage() {
@@ -58,6 +62,10 @@ function applyStyleFromStorage() {
     const compactOption = item.compactOption ?? false;
     const greenbackOption = item.greenbackOption ?? "disable";
     const columnCount = item.columnCount ?? "1";
+    const replaceMaj = item.replaceMaj ?? true;
+    const replaceAug = item.replaceAug ?? false;
+    const replaceDim = item.replaceDim ?? false;
+    const replaceHalfDim = item.replaceHalfDim ?? false;
 
     const style = styles[chordstyleOption];
     const wordFontWeight = {
@@ -140,16 +148,23 @@ function applyStyleFromStorage() {
     }
 
     if (chordstyleOption.startsWith("jazz")) {
+      const replaceEntries = [
+        replaceAug && [/aug/g, "\uE186"],
+        replaceDim && [/dim/g, "\uE187"],
+        replaceMaj && [/Maj|maj|M/g, "\uE18A"],
+        replaceHalfDim && [/m7-5|m7b5/g, "\uE18F"],
+        ["b", "\u266D"],
+        ["#", "\u266F"],
+        [/(.+)(\(.+?\))/g, "$1<sup>$2</sup>"],
+      ].filter((x) => x !== false);
       document.querySelectorAll("span.chord").forEach((chord) => {
         if (!chord.getAttribute("chord")) {
           chord.setAttribute("chord", chord.innerText);
         }
-        chord.innerHTML = chord
-          .getAttribute("chord")
-          .replaceAll("b", "\u266D")
-          .replaceAll("#", "\u266F")
-          .replaceAll(/(.+)(\(.+?\))/g, "$1<sup>$2</sup>")
-          .replaceAll(/Maj|maj|M/g, "\uE18A");
+        chord.innerHTML = chord.getAttribute("chord");
+        for (const [from, to] of replaceEntries) {
+          chord.innerHTML = chord.innerHTML.replaceAll(from, to);
+        }
       });
       const styleSheet = new CSSStyleSheet();
       styleSheet.replaceSync(`

--- a/options.css
+++ b/options.css
@@ -53,3 +53,27 @@ header img {
 .text-center {
   text-align: center;
 }
+details {
+  padding-left: 5px;
+}
+details[open] .on-close {
+  display: none;
+}
+details + .on-open {
+  display: none;
+}
+details[open] + .on-open {
+  display: block;
+}
+.center {
+  justify-self: center;
+}
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+ul li {
+  display: flex;
+  gap: 5px;
+}

--- a/options.html
+++ b/options.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>ChordWiki Bold Options</title>
+    <meta charset="UTF-8">
     <link rel="stylesheet" href="options.css">
 </head>
 <body>
@@ -43,6 +44,16 @@
         <legend>Column Count</legend>
         <label for="columnCount" id="columnCountText" class="text-center">1</label>
         <input type="range" id="columnCount" min="1" max="5" step="1" value="1"/>
+    </fieldset>
+    <details><summary><span class="on-close">Advanced</span></summary></details>
+    <fieldset class="on-open">
+        <legend>Advanced</legend>
+        <ul class="center">
+            <li><input type="checkbox" id="replaceMaj" checked>maj → △ (only in Jazz mode)</li>
+            <li><input type="checkbox" id="replaceAug">aug → + (only in Jazz mode)</li>
+            <li><input type="checkbox" id="replaceDim">dim → ○ (only in Jazz mode)</li>
+            <li><input type="checkbox" id="replaceHalfDim">m7-5 → Ø (only in Jazz mode)</li>
+        </ul>
     </fieldset>
     <script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -31,6 +31,10 @@ const options = [
   "compactOption",
   "greenbackOption",
   "columnCount",
+  "replaceMaj",
+  "replaceAug",
+  "replaceDim",
+  "replaceHalfDim",
 ];
 // Save the options
 function saveOptions() {
@@ -40,6 +44,10 @@ function saveOptions() {
     compactOption: $("compactOption").checked,
     greenbackOption: $("greenbackOption").checked ? "enable" : "disable",
     columnCount: $("columnCount").value,
+    replaceMaj: $("replaceMaj").checked,
+    replaceAug: $("replaceAug").checked,
+    replaceDim: $("replaceDim").checked,
+    replaceHalfDim: $("replaceHalfDim").checked,
   };
   chrome.storage.sync.set(values, () => {
     console.log("Option saved.");
@@ -54,6 +62,10 @@ $("columnCount").oninput = (e) => {
   $("columnCountText").innerText = e.target.value;
   saveOptions();
 };
+$("replaceMaj").onchange = saveOptions;
+$("replaceAug").onchange = saveOptions;
+$("replaceDim").onchange = saveOptions;
+$("replaceHalfDim").onchange = saveOptions;
 
 // Load the saved options
 document.addEventListener("DOMContentLoaded", () => {
@@ -64,5 +76,9 @@ document.addEventListener("DOMContentLoaded", () => {
     $("greenbackOption").checked = item.greenbackOption == "enable";
     $("columnCount").value = item.columnCount || "1";
     $("columnCountText").innerText = item.columnCount || "1";
+    $("replaceMaj").checked = item.replaceMaj || true;
+    $("replaceAug").checked = item.replaceAug || false;
+    $("replaceDim").checked = item.replaceDim || false;
+    $("replaceHalfDim").checked = item.replaceHalfDim || false;
   });
 });


### PR DESCRIPTION
### 概要

- `A7(b9,b13)` みたいなカッコ書きを上付きで表示するようにしたよ (Jazzモードのみ)
- aug -> +, dim -> ○, m7-5 -> Ø の略記を追加して、 maj -> △ とあわせてオンオフできるようにしたよ

![image](https://github.com/user-attachments/assets/d67a56c8-77cf-430c-a379-147a99ebac89)
