### PR TITLE
`/wiki/*` を表示してるときのみ拡張機能を有効にするよう修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,22 +1,14 @@
 {
-    "manifest_version": 3,
-    "name": "ChordWiki Bold",
-    "version": "1.1.0",
-    "description": "Update the style of chord spans on ChordWiki pages.",
-    "permissions": [
-      "storage"
-    ],
-    "content_scripts": [
-      {
-        "matches": ["https://ja.chordwiki.org/wiki/*"],
-        "js": ["content.js"],
-        "run_at": "document_end"
-      }
-    ],
-    "icons": {
-      "128": "icon.png"
-    },
-    "action": {
-      "default_popup": "options.html"
-    }
-  }
+  "manifest_version": 3,
+  "name": "ChordWiki Bold",
+  "version": "1.1.0",
+  "description": "Update the style of chord spans on ChordWiki pages.",
+  "permissions": ["storage"],
+  "content_scripts": [{
+    "matches": ["https://ja.chordwiki.org/wiki/*"],
+    "js": ["content.js"],
+    "run_at": "document_end"
+  }],
+  "icons": { "128": "icon.png" },
+  "action": { "default_popup": "options.html" }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     ],
     "content_scripts": [
       {
-        "matches": ["https://ja.chordwiki.org/*"],
+        "matches": ["https://ja.chordwiki.org/wiki/*"],
         "js": ["content.js"],
         "run_at": "document_end"
       }


### PR DESCRIPTION
### 概要
検索画面 `https://ja.chordwiki.org/search.html` とかでも column-count の CSS が意図せず適用されてしまってたので直したよ