### PR TITLE
余白調整と背景色オプションを追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -73,7 +73,7 @@ function applyStyleFromStorage() {
       bold: "bold",
     }[wordstyleOption];
     const backgroundColor = {
-      enable: "#00902a",
+      enable: "#00ff00",
       disable: "#ffffff",
     }[greenbackOption];
 

--- a/content.js
+++ b/content.js
@@ -47,7 +47,8 @@ const options = [
   "chordstyleOption",
   "wordstyleOption",
   "compactOption",
-  "greenbackOption",
+  "backgroundColor",
+  "backgroundColorEnabled",
   "columnCount",
   "replaceMaj",
   "replaceAug",
@@ -60,7 +61,9 @@ function applyStyleFromStorage() {
     const chordstyleOption = item.chordstyleOption ?? "bold";
     const wordstyleOption = item.wordstyleOption ?? "normal";
     const compactOption = item.compactOption ?? false;
-    const greenbackOption = item.greenbackOption ?? "disable";
+    const backgroundColor = item.backgroundColorEnabled
+      ? item.backgroundColor ?? "#00ff00"
+      : "#ffffff";
     const columnCount = item.columnCount ?? "1";
     const replaceMaj = item.replaceMaj ?? true;
     const replaceAug = item.replaceAug ?? false;
@@ -72,10 +75,6 @@ function applyStyleFromStorage() {
       normal: "normal",
       bold: "bold",
     }[wordstyleOption];
-    const backgroundColor = {
-      enable: "#00ff00",
-      disable: "#ffffff",
-    }[greenbackOption];
 
     const styleSheet = new CSSStyleSheet();
     styleSheet.replaceSync(`

--- a/content.js
+++ b/content.js
@@ -47,6 +47,8 @@ const options = [
   "chordstyleOption",
   "wordstyleOption",
   "compactOption",
+  "compactLineHeight",
+  "compactChordMargin",
   "backgroundColor",
   "backgroundColorEnabled",
   "columnCount",
@@ -61,6 +63,8 @@ function applyStyleFromStorage() {
     const chordstyleOption = item.chordstyleOption ?? "bold";
     const wordstyleOption = item.wordstyleOption ?? "normal";
     const compactOption = item.compactOption ?? false;
+    const compactLineHeight = item.compactLineHeight ?? "16";
+    const compactChordMargin = item.compactChordMargin ?? "6";
     const backgroundColor = item.backgroundColorEnabled
       ? item.backgroundColor ?? "#00ff00"
       : "#ffffff";
@@ -128,13 +132,13 @@ function applyStyleFromStorage() {
         }
         div.main span.chord, div.main span.word, div.main span.wordtop {
           position: static;
-          line-height: 1em;
+          line-height: ${compactLineHeight}px;
         }
         div.main span.wordtop {
           vertical-align: bottom;
         }
         div.main span.chord {
-          margin-right: 6px;
+          margin-right: ${compactChordMargin}px;
         }
         div.main span.word {
           white-space: pre;

--- a/options.css
+++ b/options.css
@@ -68,13 +68,34 @@ details[open] + .on-open {
 .center {
   justify-self: center;
 }
+h4 {
+  margin-block: 0;
+  font-weight: bold;
+  color: #444;
+}
 ul {
   list-style: none;
   padding: 0;
   margin: 0;
 }
-ul li {
+ul.checkbox-wrapper {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+ul.checkbox-wrapper li {
   display: flex;
   align-items: center;
   gap: 5px;
+}
+ul.number-wrapper {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px;
+}
+ul.number-wrapper span {
+  display: block;
+  font-size: 0.8em;
+}
+ul.number-wrapper input[type="number"] {
+  width: 90px;
 }

--- a/options.css
+++ b/options.css
@@ -75,5 +75,6 @@ ul {
 }
 ul li {
   display: flex;
+  align-items: center;
   gap: 5px;
 }

--- a/options.css
+++ b/options.css
@@ -33,6 +33,9 @@ header img {
   text-align: center;
   cursor: pointer;
 }
+.toggle-box-wrapper label:hover {
+  background-color: #f7f7f7;
+}
 .toggle-box-wrapper input[type="checkbox"] {
   display: none;
 }

--- a/options.html
+++ b/options.html
@@ -1,60 +1,64 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>ChordWiki Bold Options</title>
-    <meta charset="UTF-8">
-    <link rel="stylesheet" href="options.css">
+	<title>ChordWiki Bold Options</title>
+	<meta charset="UTF-8">
+	<link rel="stylesheet" href="options.css">
 </head>
 <body>
-    <header>
-        <img alt="logo" src="./icon.png" />
-        <h2>ChordWiki Bold</h2>
-    </header>
-    <fieldset>
-        <legend>Chord Style</legend>
-        <div class="toggle-box-wrapper">
-            <input type="checkbox" name="chordstyleOption" value="bold" id="chord-bold" checked/>
-            <label for="chord-bold"><img src="images/chord-bold.png"/>Bold</label>
-            <input type="checkbox" name="chordstyleOption" value="bold-large" id="chord-bold-large" />
-            <label for="chord-bold-large"><img src="images/chord-boldlarge.png"/>Bold Large</label>
-            <input type="checkbox" name="chordstyleOption" value="bold-verylarge" id="chord-bold-verylarge" />
-            <label for="chord-bold-verylarge"><img src="images/chord-boldverylarge.png"/>Bold Very Large</label>
-        </div>
-        <div class="toggle-box-wrapper">
-            <input type="checkbox" name="chordstyleOption" value="jazz" id="chord-jazz" />
-            <label for="chord-jazz"><img src="images/chord-jazz.png"/>Jazz</label>
-            <input type="checkbox" name="chordstyleOption" value="jazz-large" id="chord-jazz-large"/>
-            <label for="chord-jazz-large"><img src="images/chord-jazzlarge.png"/>Jazz Large</label>
-            <input type="checkbox" name="chordstyleOption" value="jazz-verylarge" id="chord-jazz-verylarge"/>
-            <label for="chord-jazz-verylarge"><img src="images/chord-jazzverylarge.png"/>Jazz Very Large</label>
-        </div>
-    </fieldset>
-    <fieldset>
-        <legend>Other Style</legend>
-        <div class="toggle-box-wrapper">
-            <input type="checkbox" id="wordstyleOption" />
-            <label for="wordstyleOption"><img src="images/word-bold.png"/>Word Bold</label>
-            <input type="checkbox" id="compactOption" />
-            <label for="compactOption"><img src="images/compact-compact.png"/>Compact</label>
-            <input type="checkbox" id="greenbackOption" />
-            <label for="greenbackOption"><img style="background-color: #00ff00;" src="images/word-normal.png">Greenback</label>
-        </div>
-    </fieldset>
-    <fieldset class="flex-column">
-        <legend>Column Count</legend>
-        <label for="columnCount" id="columnCountText" class="text-center">1</label>
-        <input type="range" id="columnCount" min="1" max="5" step="1" value="1"/>
-    </fieldset>
-    <details><summary><span class="on-close">Advanced</span></summary></details>
-    <fieldset class="on-open">
-        <legend>Advanced</legend>
-        <ul class="center">
-            <li><input type="checkbox" id="replaceMaj" checked>maj → △ (only in Jazz mode)</li>
-            <li><input type="checkbox" id="replaceAug">aug → + (only in Jazz mode)</li>
-            <li><input type="checkbox" id="replaceDim">dim → ○ (only in Jazz mode)</li>
-            <li><input type="checkbox" id="replaceHalfDim">m7-5 → Ø (only in Jazz mode)</li>
-        </ul>
-    </fieldset>
-    <script src="options.js"></script>
+	<header>
+		<img alt="logo" src="./icon.png" />
+		<h2>ChordWiki Bold</h2>
+	</header>
+	<fieldset>
+		<legend>Chord Style</legend>
+		<div class="toggle-box-wrapper">
+			<input type="checkbox" name="chordstyleOption" value="bold" id="chord-bold" checked/>
+			<label for="chord-bold"><img src="images/chord-bold.png"/>Bold</label>
+			<input type="checkbox" name="chordstyleOption" value="bold-large" id="chord-bold-large" />
+			<label for="chord-bold-large"><img src="images/chord-boldlarge.png"/>Bold Large</label>
+			<input type="checkbox" name="chordstyleOption" value="bold-verylarge" id="chord-bold-verylarge" />
+			<label for="chord-bold-verylarge"><img src="images/chord-boldverylarge.png"/>Bold Very Large</label>
+		</div>
+		<div class="toggle-box-wrapper">
+			<input type="checkbox" name="chordstyleOption" value="jazz" id="chord-jazz" />
+			<label for="chord-jazz"><img src="images/chord-jazz.png"/>Jazz</label>
+			<input type="checkbox" name="chordstyleOption" value="jazz-large" id="chord-jazz-large"/>
+			<label for="chord-jazz-large"><img src="images/chord-jazzlarge.png"/>Jazz Large</label>
+			<input type="checkbox" name="chordstyleOption" value="jazz-verylarge" id="chord-jazz-verylarge"/>
+			<label for="chord-jazz-verylarge"><img src="images/chord-jazzverylarge.png"/>Jazz Very Large</label>
+		</div>
+	</fieldset>
+	<fieldset>
+		<legend>Other Style</legend>
+		<div class="toggle-box-wrapper">
+			<input type="checkbox" id="wordstyleOption" />
+			<label for="wordstyleOption"><img src="images/word-bold.png"/>Word Bold</label>
+			<input type="checkbox" id="compactOption" />
+			<label for="compactOption"><img src="images/compact-compact.png"/>Compact</label>
+			<input type="checkbox" id="backgroundColorEnabled" />
+			<label for="backgroundColorEnabled">
+				<img id="background-color-icon" style="background-color: #00ff00;" src="images/word-normal.png">
+				Bg Color
+			</label>
+		</div>
+	</fieldset>
+	<fieldset class="flex-column">
+		<legend>Column Count</legend>
+		<label for="columnCount" id="columnCountText" class="text-center">1</label>
+		<input type="range" id="columnCount" min="1" max="5" step="1" value="1"/>
+	</fieldset>
+	<details><summary><span class="on-close">Advanced</span></summary></details>
+	<fieldset class="on-open">
+		<legend>Advanced</legend>
+		<ul class="center">
+			<li><input type="checkbox" id="replaceMaj" checked>maj → △ (only in Jazz mode)</li>
+			<li><input type="checkbox" id="replaceAug">aug → + (only in Jazz mode)</li>
+			<li><input type="checkbox" id="replaceDim">dim → ○ (only in Jazz mode)</li>
+			<li><input type="checkbox" id="replaceHalfDim">m7-5 → Ø (only in Jazz mode)</li>
+			<li><input type="color" id="backgroundColorPicker" value="#00ff00">Background color</li>
+		</ul>
+	</fieldset>
+	<script src="options.js"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -37,7 +37,7 @@
             <input type="checkbox" id="compactOption" />
             <label for="compactOption"><img src="images/compact-compact.png"/>Compact</label>
             <input type="checkbox" id="greenbackOption" />
-            <label for="greenbackOption"><img style="background-color: #00902a;" src="images/word-normal.png">Greenback</label>
+            <label for="greenbackOption"><img style="background-color: #00ff00;" src="images/word-normal.png">Greenback</label>
         </div>
     </fieldset>
     <fieldset class="flex-column">

--- a/options.html
+++ b/options.html
@@ -51,13 +51,27 @@
 	<details><summary><span class="on-close">Advanced</span></summary></details>
 	<fieldset class="on-open">
 		<legend>Advanced</legend>
-		<ul class="center">
-			<li><input type="checkbox" id="replaceMaj" checked>maj → △ (only in Jazz mode)</li>
-			<li><input type="checkbox" id="replaceAug">aug → + (only in Jazz mode)</li>
-			<li><input type="checkbox" id="replaceDim">dim → ○ (only in Jazz mode)</li>
-			<li><input type="checkbox" id="replaceHalfDim">m7-5 → Ø (only in Jazz mode)</li>
-			<li><input type="color" id="backgroundColorPicker" value="#00ff00">Background color</li>
+		<div class="center">
+		<h4>Chord notation (in Jazz mode)</h4>
+		<ul class="checkbox-wrapper">
+			<li><input type="checkbox" id="replaceMaj" checked>maj → △</li>
+			<li><input type="checkbox" id="replaceAug">aug → +</li>
+			<li><input type="checkbox" id="replaceDim">dim → ○</li>
+			<li><input type="checkbox" id="replaceHalfDim">m7-5 → Ø</li>
 		</ul>
+		<h4>Spacing (in Compact mode)</h4>
+		<ul class="number-wrapper">
+			<li>
+				<span>Line height (px)</span>
+				<input type="number" id="compactLineHeight" value="16">
+			</li>
+			<li>
+				<span>Chord margin (px)</span>
+				<input type="number" id="compactChordMargin" value="6">
+			</li>
+		</ul>
+		<h4>Background color</h4>
+		<input type="color" id="backgroundColorPicker" value="#00ff00">
 	</fieldset>
 	<script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -29,7 +29,8 @@ const options = [
   "chordstyleOption",
   "wordstyleOption",
   "compactOption",
-  "greenbackOption",
+  "backgroundColor",
+  "backgroundColorEnabled",
   "columnCount",
   "replaceMaj",
   "replaceAug",
@@ -42,7 +43,8 @@ function saveOptions() {
     chordstyleOption: getRadioValue("chordstyleOption") ?? "normal",
     wordstyleOption: $("wordstyleOption").checked ? "bold" : "normal",
     compactOption: $("compactOption").checked,
-    greenbackOption: $("greenbackOption").checked ? "enable" : "disable",
+    backgroundColorEnabled: $("backgroundColorEnabled").checked,
+    backgroundColor: $("backgroundColorPicker").value ?? "#00ff00",
     columnCount: $("columnCount").value,
     replaceMaj: $("replaceMaj").checked,
     replaceAug: $("replaceAug").checked,
@@ -57,7 +59,11 @@ function saveOptions() {
 setRadioBehavior("chordstyleOption", saveOptions);
 $("wordstyleOption").onchange = saveOptions;
 $("compactOption").onchange = saveOptions;
-$("greenbackOption").onchange = saveOptions;
+$("backgroundColorEnabled").onchange = saveOptions;
+$("backgroundColorPicker").onchange = (e) => {
+  $("background-color-icon").style.backgroundColor = e.target.value;
+  if ($("backgroundColorEnabled").checked) saveOptions();
+};
 $("columnCount").oninput = (e) => {
   $("columnCountText").innerText = e.target.value;
   saveOptions();
@@ -73,7 +79,10 @@ document.addEventListener("DOMContentLoaded", () => {
     setRadioValue("chordstyleOption", item.chordstyleOption || "bold");
     $("wordstyleOption").checked = item.wordstyleOption == "bold";
     $("compactOption").checked = item.compactOption;
-    $("greenbackOption").checked = item.greenbackOption == "enable";
+    $("backgroundColorEnabled").checked = item.backgroundColorEnabled;
+    const backgroundColor = item.backgroundColor ?? "#00ff00";
+    $("backgroundColorPicker").value = backgroundColor;
+    $("background-color-icon").style.backgroundColor = backgroundColor;
     $("columnCount").value = item.columnCount || "1";
     $("columnCountText").innerText = item.columnCount || "1";
     $("replaceMaj").checked = item.replaceMaj || true;

--- a/options.js
+++ b/options.js
@@ -29,6 +29,8 @@ const options = [
   "chordstyleOption",
   "wordstyleOption",
   "compactOption",
+  "compactLineHeight",
+  "compactChordMargin",
   "backgroundColor",
   "backgroundColorEnabled",
   "columnCount",
@@ -43,6 +45,8 @@ function saveOptions() {
     chordstyleOption: getRadioValue("chordstyleOption") ?? "normal",
     wordstyleOption: $("wordstyleOption").checked ? "bold" : "normal",
     compactOption: $("compactOption").checked,
+    compactLineHeight: $("compactLineHeight").value ?? "16",
+    compactChordMargin: $("compactChordMargin").value ?? "6",
     backgroundColorEnabled: $("backgroundColorEnabled").checked,
     backgroundColor: $("backgroundColorPicker").value ?? "#00ff00",
     columnCount: $("columnCount").value,
@@ -59,6 +63,8 @@ function saveOptions() {
 setRadioBehavior("chordstyleOption", saveOptions);
 $("wordstyleOption").onchange = saveOptions;
 $("compactOption").onchange = saveOptions;
+$("compactLineHeight").oninput = saveOptions;
+$("compactChordMargin").oninput = saveOptions;
 $("backgroundColorEnabled").onchange = saveOptions;
 $("backgroundColorPicker").onchange = (e) => {
   $("background-color-icon").style.backgroundColor = e.target.value;
@@ -79,6 +85,8 @@ document.addEventListener("DOMContentLoaded", () => {
     setRadioValue("chordstyleOption", item.chordstyleOption || "bold");
     $("wordstyleOption").checked = item.wordstyleOption == "bold";
     $("compactOption").checked = item.compactOption;
+    $("compactLineHeight").value = item.compactLineHeight ?? "16";
+    $("compactChordMargin").value = item.compactChordMargin ?? "6";
     $("backgroundColorEnabled").checked = item.backgroundColorEnabled;
     const backgroundColor = item.backgroundColor ?? "#00ff00";
     $("backgroundColorPicker").value = backgroundColor;


### PR DESCRIPTION
### 概要
![image](https://github.com/user-attachments/assets/94b222e1-2aa3-4d9d-8ebb-f2ba2c301dc4)
- 詳細設定にコンパクトモードの余白調整オプションと、背景色の選択を追加したよ

### その他
- デフォルトの背景色が green (#00ff00) になったよ
- トグルボタンにマウスカーソルを持ってったときに押せそうな感じを出したよ