### PR TITLE
余白調整がコード行以外にも適用されるよう修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -143,8 +143,9 @@ function applyStyleFromStorage() {
         div.main span.word {
           white-space: pre;
         }
-        div.main p.line {
+        div.main p {
           margin-block: 0 .3em;
+          line-height: ${compactLineHeight}px;
         }
       `);
       document.adoptedStyleSheets.push(styleSheet);

--- a/content.js
+++ b/content.js
@@ -143,7 +143,7 @@ function applyStyleFromStorage() {
         div.main span.word {
           white-space: pre;
         }
-        div.main p {
+        div.main p, div.main br {
           margin-block: 0 .3em;
           line-height: ${compactLineHeight}px;
         }


### PR DESCRIPTION
### 概要
- #9 の行余白調整がコメント行とかキーにも反映されるようにしたよ

### before → after
![image](https://github.com/user-attachments/assets/d6c31548-7fda-4e5d-b968-09ee199874ff)
