### PR TITLE
上付きにするコードを追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -143,8 +143,9 @@ function applyStyleFromStorage() {
         div.main span.word {
           white-space: pre;
         }
-        div.main p.line {
+        div.main p {
           margin-block: 0 .3em;
+          line-height: ${compactLineHeight}px;
         }
       `);
       document.adoptedStyleSheets.push(styleSheet);

--- a/content.js
+++ b/content.js
@@ -143,7 +143,7 @@ function applyStyleFromStorage() {
         div.main span.word {
           white-space: pre;
         }
-        div.main p {
+        div.main p, div.main br {
           margin-block: 0 .3em;
           line-height: ${compactLineHeight}px;
         }

--- a/content.js
+++ b/content.js
@@ -156,10 +156,11 @@ function applyStyleFromStorage() {
         replaceAug && [/aug/g, "\uE186"],
         replaceDim && [/dim/g, "\uE187"],
         replaceMaj && [/Maj|maj|M/g, "\uE18A"],
-        replaceHalfDim && [/m7-5|m7b5/g, "\uE18F"],
+        replaceHalfDim && [/m7[-b]5|m7\([-b]5\)/g, "\uE18F"],
         ["b", "\u266D"],
         ["#", "\u266F"],
         [/(.+)(\(.+?\))/g, "$1<sup>$2</sup>"],
+        [/^([^\(]+)([-+][59])/g, "$1<sup>$2</sup>"],
       ].filter((x) => x !== false);
       document.querySelectorAll("span.chord").forEach((chord) => {
         if (!chord.getAttribute("chord")) {

--- a/content.js
+++ b/content.js
@@ -160,7 +160,7 @@ function applyStyleFromStorage() {
         ["b", "\u266D"],
         ["#", "\u266F"],
         [/(.+)(\(.+?\))/g, "$1<sup>$2</sup>"],
-        [/^([^\(]+)([-+][59])/g, "$1<sup>$2</sup>"],
+        [/^([^\(]+)([-+][59]|omit[35])/g, "$1<sup>$2</sup>"],
       ].filter((x) => x !== false);
       document.querySelectorAll("span.chord").forEach((chord) => {
         if (!chord.getAttribute("chord")) {


### PR DESCRIPTION
### 概要
![image](https://github.com/user-attachments/assets/80b5e089-e92c-4985-bf50-7ad0c6873495)

- 機能追加
  - Bb7-5 みたいな括弧に入ってない -5, +5, -9, +9 を上付きにしたよ
  - C#7omit5 みたいな omit3, omit5 も上付きにしたよ
- 修正
  - Am7(b5) みたいな括弧つき表記でもΦに略記されるように修正したよ