### PR TITLE
maj -> △のオプションをオフにしてもUI上オンとして表示される問題を修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -143,8 +143,9 @@ function applyStyleFromStorage() {
         div.main span.word {
           white-space: pre;
         }
-        div.main p.line {
+        div.main p {
           margin-block: 0 .3em;
+          line-height: ${compactLineHeight}px;
         }
       `);
       document.adoptedStyleSheets.push(styleSheet);

--- a/content.js
+++ b/content.js
@@ -143,7 +143,7 @@ function applyStyleFromStorage() {
         div.main span.word {
           white-space: pre;
         }
-        div.main p {
+        div.main p, div.main br {
           margin-block: 0 .3em;
           line-height: ${compactLineHeight}px;
         }

--- a/content.js
+++ b/content.js
@@ -156,10 +156,11 @@ function applyStyleFromStorage() {
         replaceAug && [/aug/g, "\uE186"],
         replaceDim && [/dim/g, "\uE187"],
         replaceMaj && [/Maj|maj|M/g, "\uE18A"],
-        replaceHalfDim && [/m7-5|m7b5/g, "\uE18F"],
+        replaceHalfDim && [/m7[-b]5|m7\([-b]5\)/g, "\uE18F"],
         ["b", "\u266D"],
         ["#", "\u266F"],
         [/(.+)(\(.+?\))/g, "$1<sup>$2</sup>"],
+        [/^([^\(]+)([-+][59])/g, "$1<sup>$2</sup>"],
       ].filter((x) => x !== false);
       document.querySelectorAll("span.chord").forEach((chord) => {
         if (!chord.getAttribute("chord")) {

--- a/content.js
+++ b/content.js
@@ -160,7 +160,7 @@ function applyStyleFromStorage() {
         ["b", "\u266D"],
         ["#", "\u266F"],
         [/(.+)(\(.+?\))/g, "$1<sup>$2</sup>"],
-        [/^([^\(]+)([-+][59])/g, "$1<sup>$2</sup>"],
+        [/^([^\(]+)([-+][59]|omit[35])/g, "$1<sup>$2</sup>"],
       ].filter((x) => x !== false);
       document.querySelectorAll("span.chord").forEach((chord) => {
         if (!chord.getAttribute("chord")) {

--- a/options.js
+++ b/options.js
@@ -82,7 +82,7 @@ $("replaceHalfDim").onchange = saveOptions;
 // Load the saved options
 document.addEventListener("DOMContentLoaded", () => {
   chrome.storage.sync.get(options, (item) => {
-    setRadioValue("chordstyleOption", item.chordstyleOption || "bold");
+    setRadioValue("chordstyleOption", item.chordstyleOption ?? "bold");
     $("wordstyleOption").checked = item.wordstyleOption == "bold";
     $("compactOption").checked = item.compactOption;
     $("compactLineHeight").value = item.compactLineHeight ?? "16";
@@ -91,11 +91,11 @@ document.addEventListener("DOMContentLoaded", () => {
     const backgroundColor = item.backgroundColor ?? "#00ff00";
     $("backgroundColorPicker").value = backgroundColor;
     $("background-color-icon").style.backgroundColor = backgroundColor;
-    $("columnCount").value = item.columnCount || "1";
-    $("columnCountText").innerText = item.columnCount || "1";
-    $("replaceMaj").checked = item.replaceMaj || true;
-    $("replaceAug").checked = item.replaceAug || false;
-    $("replaceDim").checked = item.replaceDim || false;
-    $("replaceHalfDim").checked = item.replaceHalfDim || false;
+    $("columnCount").value = item.columnCount ?? "1";
+    $("columnCountText").innerText = item.columnCount ?? "1";
+    $("replaceMaj").checked = item.replaceMaj ?? true;
+    $("replaceAug").checked = item.replaceAug ?? false;
+    $("replaceDim").checked = item.replaceDim ?? false;
+    $("replaceHalfDim").checked = item.replaceHalfDim ?? false;
   });
 });


### PR DESCRIPTION
### 概要
![image](https://github.com/user-attachments/assets/1302c439-4f02-447a-83b3-49081b4e6ac4)
オフにしてもっかいオプションを表示すると
![image](https://github.com/user-attachments/assets/e11eb951-212d-4759-b52e-5fa0a771ae50)
チェックがついた状態で表示されてたから修正したよ

### 原因
`||` 演算子を使ってデフォルト値を入れようとしてたけど、 `false` が入ってきてるのに無視されちゃってた
`??` 演算子に変えると `null` or `undefined` のときだけ無視するようになるから直るよ

### Special Thanks

まぴだ報告ありがとー！