### PR TITLE
ダブルクリックと F でのフルスクリーン切り替えを削除

### DIFF
--- a/content.js
+++ b/content.js
@@ -264,12 +264,6 @@ function setFullscreen(value = true) {
     fullscreenBtn.setClose(false);
   }
 }
-document.addEventListener("keypress", (e) => {
-  if (e.key === "f") setFullscreen(!fullscreen);
-});
-document.addEventListener("dblclick", () => {
-  setFullscreen(!fullscreen);
-});
 document.addEventListener("fullscreenchange", () => {
   if (!document.fullscreenElement) setFullscreen(false);
 });

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "content_scripts": [{
     "matches": [
       "https://ja.chordwiki.org/wiki/*",
-      "https://ja.chordwiki.org/wiki.cgi*"
+      "https://ja.chordwiki.org/wiki.cgi?c=view*"
     ],
     "js": ["content.js"],
     "run_at": "document_end"


### PR DESCRIPTION
### 概要

- #15 でフルスクリーンボタンが追加されたのでダブルクリックとFは使わなくてよくなった
- 他の拡張機能 (ブラウザ内に付箋を張るやつ？) とかでダブルクリックが必要らしいので、フルスクリーンボタンがあるのにダブルクリックは不要
- コード入力画面でも F の入力や選択のためのダブルクリックが干渉してた

ので、ダブルクリックと F でのフルスクリーン切り替えは消すよ

### ほか
- `/wiki.cgi` だと編集画面 (`/wiki.cgi?c=edit`) とか履歴 (`/wiki.cgi?c=log`) とかにまで有効になっちゃうので閲覧画面 `/wiki.cgi?c=view` に限定したよ
  - Fix #21 
  - クエリ文字列なので順番が入れ変わることがある (`/wiki.cgi?t=...&c=view` とかも有効) けどレアケースなのでよしとするよ