### PR TITLE
過去の版でもプラグインが有効になるように修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
   "content_scripts": [{
     "matches": [
       "https://ja.chordwiki.org/wiki/*",
-      "https://ja.chordwiki.org/wiki.cgi?c=view*"
+      "https://ja.chordwiki.org/wiki.cgi?c=view*",
+      "https://ja.chordwiki.org/wiki.cgi?c=logview*"
     ],
     "js": ["content.js"],
     "run_at": "document_end"


### PR DESCRIPTION
### 概要

- 更新履歴から飛べる過去の版の表示でもプラグインが有効になるようにしたよ
  - e.g. https://ja.chordwiki.org/wiki.cgi?c=logview&t=%E8%8A%B1%E3%81%AB%E3%81%AA%E3%81%A3%E3%81%A6&n=20250314181626&d=2024%2F12%2F01+18%3A57%3A51+%2B0900
- 43d17bb05cf1a4292ae3da554f6930ea3915ad80 で `c=view` に絞ってたけど、 `c=logview` もコード表示される機能があったのを見落してた
- ねこふぇちさん、報告ありがと！