### PR TITLE
有効でないオプションをグレーアウトする機能を追加

### DIFF
--- a/options.html
+++ b/options.html
@@ -59,7 +59,7 @@
 			<li><input type="checkbox" id="replaceDim">dim → ○</li>
 			<li><input type="checkbox" id="replaceHalfDim">m7-5 → Ø</li>
 		</ul>
-		<h4>詰め込みの微調整</h4>
+		<h4>歌詞詰め込みのオプション</h4>
 		<ul class="number-wrapper">
 			<li>
 				<span>行間隔 (px)</span>

--- a/options.js
+++ b/options.js
@@ -20,7 +20,7 @@ function setRadioBehavior(name, onchange) {
       for (const other of elems) {
         if (elem != other) other.checked = false;
       }
-      onchange();
+      onchange(elem);
     };
   });
 }
@@ -62,9 +62,16 @@ function saveOptions() {
   });
 }
 
-setRadioBehavior("chordstyleOption", saveOptions);
+setRadioBehavior("chordstyleOption", (elem) => {
+  const enabled = elem?.checked && elem?.value.startsWith("jazz");
+  enableReplaceOptions(enabled);
+  saveOptions();
+});
 $("wordstyleOption").onchange = saveOptions;
-$("compactOption").onchange = saveOptions;
+$("compactOption").onchange = (e) => {
+  enableCompactOptions(e.target.checked);
+  saveOptions();
+};
 $("compactLineHeight").oninput = saveOptions;
 $("compactChordMargin").oninput = saveOptions;
 $("backgroundColorEnabled").onchange = saveOptions;
@@ -86,8 +93,10 @@ $("useEmbedPlayer").onchange = saveOptions;
 document.addEventListener("DOMContentLoaded", () => {
   chrome.storage.sync.get(options, (item) => {
     setRadioValue("chordstyleOption", item.chordstyleOption ?? "bold");
+    enableReplaceOptions(item.chordstyleOption.startsWith("jazz"));
     $("wordstyleOption").checked = item.wordstyleOption == "bold";
     $("compactOption").checked = item.compactOption;
+    enableCompactOptions(item.compactOption);
     $("compactLineHeight").value = item.compactLineHeight ?? "16";
     $("compactChordMargin").value = item.compactChordMargin ?? "6";
     $("backgroundColorEnabled").checked = item.backgroundColorEnabled;
@@ -103,3 +112,15 @@ document.addEventListener("DOMContentLoaded", () => {
     $("useEmbedPlayer").checked = item.useEmbedPlayer ?? true;
   });
 });
+
+function enableReplaceOptions(enabled) {
+  $("replaceMaj").disabled = !enabled;
+  $("replaceAug").disabled = !enabled;
+  $("replaceDim").disabled = !enabled;
+  $("replaceHalfDim").disabled = !enabled;
+}
+
+function enableCompactOptions(enabled) {
+  $("compactLineHeight").disabled = !enabled;
+  $("compactChordMargin").disabled = !enabled;
+}


### PR DESCRIPTION
### やったこと
- コード略記と詰め込み微調整をそれぞれ丸文字モード、詰め込みモードじゃないときにグレーアウトするようにしたよ (下記画像参照)
- 「詰め込みの微調整」を「歌詞詰め込みのオプション」としたよ
  - Fix #23 

![image](https://github.com/user-attachments/assets/34b1f9b3-1158-4944-aed3-5f87d90730cf)
