### PR TITLE
コードが挿入されている部分に隙間を追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -135,6 +135,9 @@ function applyStyleFromStorage() {
           display: inline-flex;
           flex-direction: column;
         }
+        div.main span.chordword, div.main span.wordtop {
+          margin-right: 5px;
+        }
         div.main span.chord, div.main span.word, div.main span.wordtop {
           position: static;
           line-height: ${compactLineHeight}px;

--- a/content.js
+++ b/content.js
@@ -321,7 +321,6 @@ function enableEmbedPlayer() {
   };
   videoPlayer.init();
   document.querySelectorAll(".movie a").forEach((movie) => {
-    console.log(movie);
     if (movie.href.startsWith("https://www.youtube.com")) {
       const videoId = movie.href.split("?v=").pop();
       if (videoId) {

--- a/options.html
+++ b/options.html
@@ -59,7 +59,7 @@
 			<li><input type="checkbox" id="replaceDim">dim → ○</li>
 			<li><input type="checkbox" id="replaceHalfDim">m7-5 → Ø</li>
 		</ul>
-		<h4>詰め込みの微調整</h4>
+		<h4>歌詞詰め込みのオプション</h4>
 		<ul class="number-wrapper">
 			<li>
 				<span>行間隔 (px)</span>

--- a/options.js
+++ b/options.js
@@ -20,7 +20,7 @@ function setRadioBehavior(name, onchange) {
       for (const other of elems) {
         if (elem != other) other.checked = false;
       }
-      onchange();
+      onchange(elem);
     };
   });
 }
@@ -62,9 +62,16 @@ function saveOptions() {
   });
 }
 
-setRadioBehavior("chordstyleOption", saveOptions);
+setRadioBehavior("chordstyleOption", (elem) => {
+  const enabled = elem?.checked && elem?.value.startsWith("jazz");
+  enableReplaceOptions(enabled);
+  saveOptions();
+});
 $("wordstyleOption").onchange = saveOptions;
-$("compactOption").onchange = saveOptions;
+$("compactOption").onchange = (e) => {
+  enableCompactOptions(e.target.checked);
+  saveOptions();
+};
 $("compactLineHeight").oninput = saveOptions;
 $("compactChordMargin").oninput = saveOptions;
 $("backgroundColorEnabled").onchange = saveOptions;
@@ -86,8 +93,10 @@ $("useEmbedPlayer").onchange = saveOptions;
 document.addEventListener("DOMContentLoaded", () => {
   chrome.storage.sync.get(options, (item) => {
     setRadioValue("chordstyleOption", item.chordstyleOption ?? "bold");
+    enableReplaceOptions(item.chordstyleOption.startsWith("jazz"));
     $("wordstyleOption").checked = item.wordstyleOption == "bold";
     $("compactOption").checked = item.compactOption;
+    enableCompactOptions(item.compactOption);
     $("compactLineHeight").value = item.compactLineHeight ?? "16";
     $("compactChordMargin").value = item.compactChordMargin ?? "6";
     $("backgroundColorEnabled").checked = item.backgroundColorEnabled;
@@ -103,3 +112,15 @@ document.addEventListener("DOMContentLoaded", () => {
     $("useEmbedPlayer").checked = item.useEmbedPlayer ?? true;
   });
 });
+
+function enableReplaceOptions(enabled) {
+  $("replaceMaj").disabled = !enabled;
+  $("replaceAug").disabled = !enabled;
+  $("replaceDim").disabled = !enabled;
+  $("replaceHalfDim").disabled = !enabled;
+}
+
+function enableCompactOptions(enabled) {
+  $("compactLineHeight").disabled = !enabled;
+  $("compactChordMargin").disabled = !enabled;
+}


### PR DESCRIPTION
- 不要な `console.log` を削除したよ
- コード歌詞のかたまりの後ろに隙間をちょっとあけるようにしたよ
  - #22 の部分的な解決になるかも？
  - 英字の場合はだいぶ読みやすくなった
##### before
![Image](https://github.com/user-attachments/assets/aea4bda8-88a2-433d-8744-5a0be071718c)
##### after
![image](https://github.com/user-attachments/assets/aa50f4e7-cc35-4fcc-874f-f3aaf4a9efef)


